### PR TITLE
Fix argparser instance to be accessible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@soos-io/api-client",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@soos-io/api-client",
-      "version": "0.2.33",
+      "version": "0.2.34",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soos-io/api-client",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "description": "This is the SOOS API Client for registered clients leveraging the various integrations to the SOOS platform.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/services/ArgumentParserBase.ts
+++ b/src/services/ArgumentParserBase.ts
@@ -19,9 +19,9 @@ interface ICommonArguments {
 }
 
 abstract class ArgumentParserBase {
+  public argumentParser: ArgumentParser;
   protected scanType?: ScanType;
   protected scriptVersion: string = "0.0.0";
-  protected argumentParser: ArgumentParser;
   protected integrationName?: IntegrationName;
   protected integrationType?: IntegrationType;
 


### PR DESCRIPTION
### Changes:
  - Description of the change
  - Updated package.json version

**Ticket:** https://soos.atlassian.net/browse/PA-0000

<!---
pre release: 
set package.json version eg "version": "0.1.3-pre.1"
npm run build
npm publish --tag next

If you want to create a release make sure to bump the version on package.json, once it's merged just push a tag with the version
eg if package version is 1.0.0 push a tag with the version v1.0.0 (make sure to use the v as a prefix).
 This will be enough to release a new version
-->
